### PR TITLE
Reducing what is pushed from data directory

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -143,6 +143,9 @@ exclude:
   - _core/resolver.md
   - _core/search.md
   - _core/subdomain.md
+  - _data/*.yml
+  - _data/*.csv
+  - _data/cliRef.json
 
 sass:
   style:            compressed


### PR DESCRIPTION
- Make sure the _data directory served only contains the data we want to share.

Signed-off-by: Mary Anthony <mary@blockstack.com>