### PR TITLE
Gaia: Add steps for granting read permission to space to Digital Ocean

### DIFF
--- a/_storage/digital-ocean-deploy.md
+++ b/_storage/digital-ocean-deploy.md
@@ -73,8 +73,39 @@ In this task you create a **Space** which is where Gaia stores your files.
 
    After a moment, your Space is up and running.
 
+6. Enable **File Listing** for your space
 
-## Task 2: Create a DigitalOcean droplet
+   Click on your space, then click on the settings tab and enable File Listing.
+
+## Task 2: Grant Read Permission with a Bucket Policy
+
+1. Install and configure **s3cmd** on your development machine by following these instructions:
+
+   https://www.digitalocean.com/docs/spaces/resources/s3cmd/
+
+2. Create a bucket policy file `policy` and save it locally, replacing `SPACE_NAME` with the name of the space you created. Don't change any of the other fields, especially `Version.`
+
+    ```
+    {
+      "Version":"2012-10-17",
+      "Id": "read policy",
+      "Statement":[
+        {
+          "Sid":"PublicRead",
+          "Effect":"Allow",
+          "Principal": "*",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::<SPACE_NAME>/*"
+        }
+      ]
+    }
+    ```
+
+3. Use `s3cmd` to enact the policy, again replacing `SPACE_NAME` with the name of your space.
+
+    `s3cmd setpolicy gaiahub-policy s3://<SPACE_NAME>`
+
+## Task 3: Create a DigitalOcean droplet
 
 In this task, you add a droplet to your account. The droplet is a droplet is a cloud-based server you can use as a compute resource. This server is where you will run the Gaia Storage System service. The droplet you create will be an Ubuntu server with Docker pre-installed.
 
@@ -116,7 +147,7 @@ In this task, you add a droplet to your account. The droplet is a droplet is a c
 At this point, your new droplet should appear in the list of resources on your DigitalOcean dashboard.
 
 
-## Task 3: Open a console on your Droplet
+## Task 4: Open a console on your Droplet
 
 A droplet console emulates the access you would have if you were sitting down with a keyboard and monitor attached to the actual server. In this section, you open a console on your droplet.
 
@@ -177,7 +208,7 @@ A droplet console emulates the access you would have if you were sitting down wi
 </div>
 
 
-## Task 4: Create a space key
+## Task 5: Create a space key
 
 1. In the DigitalOcean dashboard, go to the **API** page.
 2. Scroll to the **Spaces Access Keys** section.
@@ -201,7 +232,7 @@ A droplet console emulates the access you would have if you were sitting down wi
 
 7. Leave the page up with your key and secret and go to your open console.
 
-## Task 5: Get the Gaia code and configure your server
+## Task 6: Get the Gaia code and configure your server
 
 You should have the console open as `root` on your Droplet. In this section, you get the Gaia code and configure the Gaia service.
 
@@ -326,7 +357,7 @@ You should have the console open as `root` on your Droplet. In this section, you
 
     The system returns you back to the prompt.
 
-## Task 6: Run the Gaia image with Docker
+## Task 7: Run the Gaia image with Docker
 
 While your console is still in the the `gaia/hub` folder, build the `gaia.hub` image.
 
@@ -389,7 +420,7 @@ While your console is still in the the `gaia/hub` folder, build the `gaia.hub` i
 
 At this point, your Gaia service is up and running. You can run `docker logs MY_CONTAINER_ID` with your running image's ID to see the logs of this server at any time.
 
-## Task 7: Set up an Nginx reverse proxy
+## Task 8: Set up an Nginx reverse proxy
 
 In this task, you set up a simple Nginx reverse proxy to serve your Docker container through a public URL. You do this from the droplet console command line.
 
@@ -442,7 +473,7 @@ In this task, you set up a simple Nginx reverse proxy to serve your Docker conta
     ufw allow 80
     ```
 
-## Task 8: Test your Gaia server
+## Task 9: Test your Gaia server
 
 Now, you are ready to test your Gaia server and make sure it is up and running.
 
@@ -463,7 +494,7 @@ Now, you are ready to test your Gaia server and make sure it is up and running.
     `https://meepers-hub-space.s3.amazonaws.com/`.
 
 
-## Task 9: Configure a domain name
+## Task 10: Configure a domain name
 
 
 At this point, you can point a domain to your Gaia hub. Although it's not required, it is highly recommended. If you use a domain, you can migrate your Droplet to a different server (or even provider such as Azure or AWS) at any time, and still access it through the domain URL. Simply point your domain at the IP address for your Droplet. Use an `A Record` DNS type.
@@ -493,7 +524,7 @@ These instructions assume you have already created a free <a href="https://www.f
    ![Domain test](/storage/images/domain-test.png)
 
 
-## Task 10: Set up SSL
+## Task 11: Set up SSL
 
 If you've configured a domain to point to your Gaia hub, then it's highly
 recommended that you set up SSL to connect to your hub securely. DigitalOcean

--- a/_storage/digital-ocean-deploy.md
+++ b/_storage/digital-ocean-deploy.md
@@ -447,6 +447,17 @@ In this task, you set up a simple Nginx reverse proxy to serve your Docker conta
           proxy_set_header Connection 'upgrade';
           proxy_set_header Host $host;
           proxy_cache_bypass $http_upgrade;
+
+          if ($request_method = 'OPTIONS') {
+                    more_set_headers   'Access-Control-Allow-Origin: *';
+                    more_set_headers   'Access-Control-Allow-Methods: POST, OPTIONS, DELETE';
+                    more_set_headers   'Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, authorization';
+                    more_set_headers   'Access-Control-Max-Age: 21600';
+                    more_set_headers   'Content-Type: text/plain charset=UTF-8';
+                    more_set_headers   'Content-Length: 0';
+                    return             204;
+          }
+          more_set_headers    'Access-Control-Allow-Origin: *';
     }
     ```
 


### PR DESCRIPTION
This PR addresses two issues:

1. In order for Gaia Hub to work properly it must be able to request a file from its datastore. If the file doesn't exist, the hub expects the data store to return a 404 error. With digital ocean spaces, if `File Listing` isn't enabled, it will return a 403 error.

2. The data store must have a public read policy enabled.