### PR TITLE
fix content->browser bug

### DIFF
--- a/collections.json
+++ b/collections.json
@@ -10,7 +10,7 @@
      "repo": "https://github.com/blockstack/blockstack-core"
    },
    {
-    "name": "browser",
+    "name": "android",
     "repo": "https://github.com/blockstack/blockstack-android"
   },
   {


### PR DESCRIPTION
The "_browser" folder will be update twice in the "get_content.sh" script.

- The first "name" and "repo" is correct, the svn will download file from right repo address 
- But the second is wrong, it will delete the "right" _browser folder and create a new one with android repo's source

This will lead to the browser page not found. (From i tried)
It is simple to figure out, i think i don't need to put any picture here.
