### PR TITLE
add redirects for zero to dapp URLs

### DIFF
--- a/_browser/hello-blockstack.md
+++ b/_browser/hello-blockstack.md
@@ -2,6 +2,11 @@
 layout: learn
 description: Simple Blockstack web App
 permalink: /:collection/:path.html
+redirect_from:
+  - /develop/zero_to_dapp_1.html
+  - /develop/zero_to_dapp_2.html
+  - /develop/zero_to_dapp_3.html
+  - /develop/zero_to_dapp_4.html
 ---
 # Hello, Blockstack
 


### PR DESCRIPTION
The old URLs will redirect to the Hello, Blockstack tutorial (https://docs.blockstack.org/browser/hello-blockstack.html)