### PR TITLE
feat: add docs for mining

### DIFF
--- a/_core/smart/neon-node.md
+++ b/_core/smart/neon-node.md
@@ -80,7 +80,7 @@ To get a keychain, the simplest way is to use the `blockstack-cli`. We'll use th
 npx blockstack-cli@1.1.0-beta.1 make_keychain -t
 ```
 
-After this runs, you should see some output that looks like this:
+After this runs, you'll probably see some installation logs, and at the end you should see some JSON that looks like this:
 
 ```json
 {
@@ -94,7 +94,7 @@ After this runs, you should see some output that looks like this:
 }
 ```
 
-We need to get some testnet BTC to that address. Grab the `btcAddress` field, and head over to [the Stacks testnet website](https://testnet.blockstack.org/faucet). In the BTC faucet section, past in your `btcAddress`, and submit. You'll be sent 0.5 testnet BTC to that address. Don't lose this information - we'll need to use the `privateKey` field later on.
+We need to get some testnet BTC to that address. Grab the `btcAddress` field, and head over to [the Stacks testnet website](https://testnet.blockstack.org/faucet). In the BTC faucet section, past in your `btcAddress`, and submit. You'll be sent 0.5 testnet BTC to that address. **Don't lose this information** - we'll need to use the `privateKey` field later on.
 
 Now, we need to configure out node to use this Bitcoin keychain. In the `stacks-blockchain` folder, create a new file called `testnet/stacks-node/conf/neon-miner-conf.toml`.
 
@@ -135,7 +135,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start config=./testnet/stacks-node/conf/neon-miner-conf.toml
+stacks-node start --config=./testnet/stacks-node/conf/neon-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running!

--- a/_core/smart/neon-node.md
+++ b/_core/smart/neon-node.md
@@ -47,7 +47,7 @@ cd stacks-blockchain
 Install the Stacks node by running:
 
 ```bash
-cargo install --path ./testnet
+cargo install --path ./testnet/stacks-node
 ```
 
 ### Run your node
@@ -67,6 +67,78 @@ INFO [1588108047.585] [src/chainstate/stacks/index/marf.rs:732] First-ever block
 ```
 
 Awesome! Your node is now connected to the Neon network. Your node will receive new blocks when they are produced, and you can use your [node's RPC API](/core/smart/rpc-api) to send transactions, fetch information for contracts and accounts, and more.
+
+### Running a miner
+
+Once you've followed the above steps to run a node, it's only a few more steps to run a Proof-of-burn miner on the Neon testnet.
+
+First, we need to generate a keychain. With this keychain, we'll get some testnet BTC from a faucet, and then use that BTC to start mining.
+
+To get a keychain, the simplest way is to use the `blockstack-cli`. We'll use the `make_keychain` command, and pass `-t` to indicate that we want a testnet keychain.
+
+```bash
+npx blockstack-cli@1.1.0-beta.1 make_keychain -t
+```
+
+After this runs, you should see some output that looks like this:
+
+```json
+{
+  "mnemonic": "exhaust spin topic distance hole december impulse gate century absent breeze ostrich armed clerk oak peace want scrap auction sniff cradle siren blur blur",
+  "keyInfo": {
+    "privateKey": "2033269b55026ff2eddaf06d2e56938f7fd8e9d697af8fe0f857bb5962894d5801",
+    "address": "STTX57EGWW058FZ6WG3WS2YRBQ8HDFGBKEFBNXTF",
+    "btcAddress": "mkRYR7KkPB1wjxNjVz3HByqAvVz8c4B6ND",
+    "index": 0
+  }
+}
+```
+
+We need to get some testnet BTC to that address. Grab the `btcAddress` field, and head over to [the Stacks testnet website](https://testnet.blockstack.org/faucet). In the BTC faucet section, past in your `btcAddress`, and submit. You'll be sent 0.5 testnet BTC to that address. Don't lose this information - we'll need to use the `privateKey` field later on.
+
+Now, we need to configure out node to use this Bitcoin keychain. In the `stacks-blockchain` folder, create a new file called `testnet/stacks-node/conf/neon-miner-conf.toml`.
+
+Paste in the following configuration:
+
+```toml
+[node]
+rpc_bind = "0.0.0.0:20443"
+p2p_bind = "0.0.0.0:20444"
+bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@neon.blockstack.org:20444"
+# Enter your private key here!
+seed = "replace-with-your-private-key"
+miner = true
+
+[burnchain]
+chain = "bitcoin"
+mode = "neon"
+peer_host = "neon.blockstack.org"
+rpc_port = 18443
+peer_port = 18444
+
+[[mstx_balance]]
+address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
+amount = 10000000000000000
+[[mstx_balance]]
+address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
+amount = 10000000000000000
+[[mstx_balance]]
+address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
+amount = 10000000000000000
+[[mstx_balance]]
+address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
+amount = 10000000000000000
+```
+
+Now, grab your `privateKey` from earlier, when you ran the `make_keychain` command. Replace the `seed` field with your private key. Save and close this configuration file.
+
+To run your miner, run this in the command line:
+
+```bash
+stacks-node start config=./testnet/stacks-node/conf/neon-miner-conf.toml
+```
+
+Your node should start. It will take some time to sync, and then your miner will be running!
 
 ### Creating an optimized binary
 


### PR DESCRIPTION
Added to the `neon-node` page for how to run a miner.

**Blockers**:
- We need this merged and deployed: https://github.com/blockstack/stacks-blockchain-sidecar/pull/92
- We need the testnet website updated with the BTC faucet form. Right now, that's staged at https://testnet-staging.blockstack.org/faucet