### PR TITLE
Use correct path to install neon node

### DIFF
--- a/_core/smart/neon-node.md
+++ b/_core/smart/neon-node.md
@@ -47,7 +47,7 @@ cd stacks-blockchain
 Install the Stacks node by running:
 
 ```bash
-cargo install --path ./testnet
+cargo install --path=./testnet/stacks-node
 ```
 
 ### Run your node


### PR DESCRIPTION
This PR
* uses path `testnet/stacksnode` instead of `testnet` to install stacks-node