### PR TITLE
Fix Blockstack CLI title in navigation

### DIFF
--- a/_develop/cliDocs.md
+++ b/_develop/cliDocs.md
@@ -2,6 +2,6 @@
 layout: learn
 permalink: /:collection/:path.html
 ---
-# blockstack_cli reference
+# Blockstack CLI Reference
 
 {% include commandline.md %}


### PR DESCRIPTION
Changes `blockstack_cli` to "Blockstack CLI" in nav.