### PR TITLE
Update CLI wallet quickstart, simplifying commands

### DIFF
--- a/_core/smart/cli-wallet-quickstart.md
+++ b/_core/smart/cli-wallet-quickstart.md
@@ -22,13 +22,14 @@ To install the Blockstack CLI, run the following command in terminal.
 First, we are going to generate a new wallet for Testnet. To generate a wallet use the `make_keychain` command with the `-t` option for Testnet.
 
 ```
-$ blockstack-cli make_keychain -t
+$ blockstack make_keychain -t
 
 {
   "mnemonic": "private unhappy random runway boil scissors remove harvest fatigue inherit inquiry still before mountain pet tail mad accuse second milk client rebuild salt chase",
   "keyInfo": {
     "privateKey": "381314da39a45f43f45ffd33b5d8767d1a38db0da71fea50ed9508e048765cf301",
     "address": "ST1BG7MHW2R524WMF7X8PGG3V45ZN040EB9EW0GQJ",
+    "btcAddress": "n4X37UmRZYk9HawtS1w4xRtqJWhByxiz3c",
     "index": 0
   }
 }
@@ -54,17 +55,21 @@ Once the faucet transaction has been broadcasted, you will need to wait for the 
 Once you’ve requested Testnet Stacks tokens from the faucet, you can check the balance of your account using the following command. 
 
 ```
-$ blockstack-cli balance ST1BG7MHW2R524WMF7X8PGG3V45ZN040EB9EW0GQJ -H "http://neon.blockstack.org:20443"
+$ blockstack balance ST1BG7MHW2R524WMF7X8PGG3V45ZN040EB9EW0GQJ -t
 
 {
-  "balance": "1000",
+  "balance": "10000",
   "nonce": 0
 }
 ``` 
 
-Using the `-H` option, we specify a connection to the testnet node at `http://neon.blockstack.org:20443`
+By default, using the `-t` flag causes the CLI to connect to the neon testnet node at `http://neon.blockstack.org:20443`.
+
+To specify a node to connect to, add the `-H` flag followed by the URL of the node `"http://localhost:20443"`. This flag can be used with all commands in this guide.
 
 Verify that your account has tokens before continuing to the next step to send tokens.
+
+Take note that the nonce for the account is `0`. We will be using this number in the next step.
 
 ## Sending Tokens
 
@@ -83,22 +88,21 @@ In order to send tokens, we will need the 5 parameters below.
 Once we have the parameters, we can use the  `send_tokens` command:
 
 ```
-$ blockstack-cli send_tokens ST1WZ69T99RHQMQX3D91ZH2R37GV5NK8KDS5D5VDZ 1000 200 0 381314da39a45f43f45ffd33b5d8767d1a38db0da71fea50ed9508e048765cf301 -t -T "http://neon.blockstack.org:20443/v2/transactions"
+$ blockstack send_tokens ST2KMMVJAB00W5Z6XWTFPH6B13JE9RJ2DCSHYX0S7 1000 200 0 381314da39a45f43f45ffd33b5d8767d1a38db0da71fea50ed9508e048765cf301 -t
 
 d32de0d66b4a07e0d7eeca320c37a10111c8c703315e79e17df76de6950c622c
 ```    
 
-With this command we’re sending 1000 microstacks to the Stacks address `ST1WZ69T99RHQMQX3D91ZH2R37GV5NK8KDS5D5VDZ`. 
+With this command we’re sending 1000 microstacks to the Stacks address `ST2KMMVJAB00W5Z6XWTFPH6B13JE9RJ2DCSHYX0S7`. 
 
-We set the fee rate to `200` microstacks. 
+We set the fee rate to `200` microstacks. If you're not sure how much your transaction will cost. You can add the `-e` flag to estimate the transaction fee needed to get processed by the network, without broadcasting your transaction. 
 
-The nonce is set to `0` for this transaction, since it will be the first transaction we send from this account. 
+The nonce is set to `0` for this transaction, since it will be the first transaction we send from this account. For subsequent transactions, you will need to increment this number by `1` each time. You can check the current nonce for the account using the `balance` command.
 
 Finally, the last parameter is the private key from earlier. `381314da39a45f43f45ffd33b5d8767d1a38db0da71fea50ed9508e048765cf301` 
 
 Once again, we’re using the `-t` option to indicate that this is a Testnet transaction, so it should be broadcasted to Testnet.
 
-Using the `-T` option, we specify that we want to broadcast to the testnet node at `http://neon.blockstack.org:20443/v2/transactions`
-
 If valid, your transaction will now be broadcasted to the network and you will see the transaction ID displayed on the screen.
 
+To view the raw transaction without broadcasting, add the `-x` flag to your command.


### PR DESCRIPTION
Updates to the simplified commands recently pushed to the Stacks 2.0 CLI PR. Node URL no longer needs to be specified when using the `-t` flag.