### PR TITLE
feat: update node docs for argon

### DIFF
--- a/_core/smart/neon-node.md
+++ b/_core/smart/neon-node.md
@@ -3,10 +3,10 @@ layout: smart
 description: "Run a Stacks Testnet Node"
 permalink: /:collection/:path.html
 ---
-# Running a Neon Testnet Node
+# Running a Testnet Node
 {:.no_toc}
 
-"Neon" is phase 1 of the Stacks 2.0 testnet. In Neon, you can run a node and connect it to a public network. This guide will walk you through downloading and running your own node in the Neon network.
+The Stacks 2.0 testnet is currently in development. As part of the testnet, you can run a node and connect it to a public network. This guide will walk you through downloading and running your own node in the testnet network.
 
 * TOC
 {:toc}
@@ -18,9 +18,7 @@ Note: If you use Linux, you may need to manually install [`libssl-dev`](https://
 sudo apt-get install build-essential cmake libssl-dev pkg-config
 ```
 
-### Download and install the `stacks-blockchain` repository
-
-The first step is to ensure that you have Rust installed. If you are using macOS, Linux, or another Unix-like OS, run the following. If you are on a different OS, follow the [official Rust installation guide](https://www.rust-lang.org/tools/install).
+Ensure that you have Rust installed. If you are using macOS, Linux, or another Unix-like OS, run the following. If you are on a different OS, follow the [official Rust installation guide](https://www.rust-lang.org/tools/install).
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -35,6 +33,8 @@ In case you just installed Rust, you will be prompted to run the following comma
 ```bash
 source $HOME/.cargo/env
 ```
+
+### Download and install the `stacks-blockchain` repository
 
 Next, clone this repository:
 
@@ -52,12 +52,12 @@ cargo install --path ./testnet/stacks-node
 
 ### Run your node
 
-You're all set to run a node that connects to the Neon network.
+You're all set to run a node that connects to the testnet network.
 
 Back in the command line, run:
 
 ```bash
-stacks-node neon
+stacks-node argon
 ```
 
 The first time you run this, you'll see some logs indicating that the Rust code is being compiled. Once that's done, you should see some logs that look something like the this:
@@ -66,11 +66,11 @@ The first time you run this, you'll see some logs indicating that the Rust code 
 INFO [1588108047.585] [src/chainstate/stacks/index/marf.rs:732] First-ever block 0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
 ```
 
-Awesome! Your node is now connected to the Neon network. Your node will receive new blocks when they are produced, and you can use your [node's RPC API](/core/smart/rpc-api) to send transactions, fetch information for contracts and accounts, and more.
+Awesome! Your node is now connected to the testnet network. Your node will receive new blocks when they are produced, and you can use your [node's RPC API](/core/smart/rpc-api) to send transactions, fetch information for contracts and accounts, and more.
 
 ### Running a miner
 
-Once you've followed the above steps to run a node, it's only a few more steps to run a Proof-of-burn miner on the Neon testnet.
+Once you've followed the above steps to run a node, it's only a few more steps to run a proof-of-burn miner on the testnet.
 
 First, we need to generate a keychain. With this keychain, we'll get some testnet BTC from a faucet, and then use that BTC to start mining.
 
@@ -96,7 +96,7 @@ After this runs, you'll probably see some installation logs, and at the end you 
 
 We need to get some testnet BTC to that address. Grab the `btcAddress` field, and head over to [the Stacks testnet website](https://testnet.blockstack.org/faucet). In the BTC faucet section, past in your `btcAddress`, and submit. You'll be sent 0.5 testnet BTC to that address. **Don't lose this information** - we'll need to use the `privateKey` field later on.
 
-Now, we need to configure out node to use this Bitcoin keychain. In the `stacks-blockchain` folder, create a new file called `testnet/stacks-node/conf/neon-miner-conf.toml`.
+Now, we need to configure out node to use this Bitcoin keychain. In the `stacks-blockchain` folder, create a new file called `testnet/stacks-node/conf/testnet-miner-conf.toml`.
 
 Paste in the following configuration:
 
@@ -104,15 +104,15 @@ Paste in the following configuration:
 [node]
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
-bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@neon.blockstack.org:20444"
+bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@testnet-master.blockstack.org:20444"
 # Enter your private key here!
 seed = "replace-with-your-private-key"
 miner = true
 
 [burnchain]
 chain = "bitcoin"
-mode = "neon"
-peer_host = "neon.blockstack.org"
+mode = "argon"
+peer_host = "argon.blockstack.org"
 rpc_port = 18443
 peer_port = 18444
 
@@ -135,7 +135,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/neon-miner-conf.toml
+stacks-node start --config=./testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running!
@@ -153,7 +153,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./testnet/conf/neon-follower-conf.toml
+./target/release/stacks-node start --config=./testnet/conf/argon-follower-conf.toml
 ```
 
 ### Enable debug logging
@@ -161,5 +161,5 @@ cd ../..
 In case you are running into issues or would like to see verbose logging, you can run your node with debug logging enabled. In the command line, run:
 
 ```bash
-BLOCKSTACK_DEBUG=1 stacks-node neon
+BLOCKSTACK_DEBUG=1 stacks-node argon
 ```

--- a/_core/smart/testnet-node.md
+++ b/_core/smart/testnet-node.md
@@ -2,6 +2,8 @@
 layout: smart
 description: "Run a Stacks Testnet Node"
 permalink: /:collection/:path.html
+redirect_from:
+  - /core/smart/neon-node.html
 ---
 # Running a Testnet Node
 {:.no_toc}

--- a/_core/smart/testnet-node.md
+++ b/_core/smart/testnet-node.md
@@ -106,7 +106,7 @@ Paste in the following configuration:
 [node]
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
-bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@testnet-master.blockstack.org:20444"
+bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@argon.blockstack.org:20444"
 # Enter your private key here!
 seed = "replace-with-your-private-key"
 miner = true


### PR DESCRIPTION
This PR does the following:

- Updates miner conf's `bootstrap_node` to use the stable domain `testnet-master.blockstack.org`, which shouldn't change during later testnet phases.
- Updates miner conf's `mode` and `peer_host` for argon.
- Updated any CLI commands to use `argon` instead of `neon`, i.e. `stacks-node argon`.
- Removed any reference to "Neon network", and replaced it with more generic language like "testnet network".