### PR TITLE
Updating bootstrap_node key in the miner config so external neighbors are known

### DIFF
--- a/src/pages/mining.md
+++ b/src/pages/mining.md
@@ -52,7 +52,7 @@ Paste in the following configuration:
 [node]
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
-bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@argon.blockstack.org:20444"
+bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@argon-master.blockstack.org:20444"
 # Enter your private key here!
 seed = "replace-with-your-private-key"
 miner = true


### PR DESCRIPTION
Current miner config is using the older `argon.blockstack.org` DNS entry, which isn't able to track external IPs for http://argon.blockstack.org:20443/v2/neighbors

Using the DNS `argon-master.blockstack.org` resolves this issue so external neighbors are known to miners. 